### PR TITLE
Update umd to 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "concat-stream": "~1.4.1",
     "defined": "~0.0.0",
     "through2": "~0.5.1",
-    "umd": "^2.1.0"
+    "umd": "^3.0.0"
   },
   "devDependencies": {
     "tap": "~0.4.0",


### PR DESCRIPTION
This is a small breaking change.  If people compile modules with standalone names like:

```js
browserify foo.js --standalone $foo_bar > out.js
```

They would previously have a module that attached to the global as `foobar` but would now have a module that attaches to the global as `$foo_bar`.