### PR TITLE
Guard against malformed standalone bundle.

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,8 +97,8 @@ module.exports = function (opts) {
         entries = entries.filter(function (x) { return x !== undefined });
         
         stream.push(Buffer('},{},' + JSON.stringify(entries) + ')'));
-        
-        if (opts.standalone) {
+
+        if (opts.standalone && !first) {
             stream.push(Buffer(
                 '(' + JSON.stringify(stream.standaloneModule) + ')'
                 + umd.postlude(opts.standalone)


### PR DESCRIPTION
If you do:

```js
browserify().bundle()
```
You get an empty and useless bundle, but no browser error. Whereas if you do:

```js
browserify({standalone: 'whatever'}).bundle()
```
You get a malformed bundle and a browser error.

I think in both cases it should either:

A) Produce an empty and useless but well-formed bundle; or

B) Error out during bundling.

This PR does A, making the standalone behavior consistent with non-standalone.

The only time [`first === true` in `end()`](https://github.com/substack/browser-pack/blob/cb83c2fb857db7d32c2844cd15495c35efabe698/index.js#L96) is when the bundle is empty, right?