### PR TITLE
Remove require in standalone mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var JSONStream = require('JSONStream');
 var defined = require('defined');
 var through = require('through2');
 var umd = require('umd');
+var removeRequire = require('remove-require');
 
 var fs = require('fs');
 var path = require('path');
@@ -66,12 +67,19 @@ module.exports = function (opts) {
             );
         }
         
+        var rowSource;
+        if (opts.standalone) {
+            rowSource = removeRequire(row.source);
+        } else {
+            rowSource = {name: 'require', src: row.source};
+        }
+        
         var wrappedSource = [
             (first ? '' : ','),
             JSON.stringify(row.id),
             ':[',
-            'function(require,module,exports){\n',
-            combineSourceMap.removeComments(row.source),
+            'function(' + rowSource.name + ',module,exports){\n',
+            combineSourceMap.removeComments(rowSource.src),
             '\n},',
             '{' + Object.keys(row.deps || {}).sort().map(function (key) {
                 return JSON.stringify(key) + ':'

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "combine-source-map": "~0.3.0",
     "concat-stream": "~1.4.1",
     "defined": "~0.0.0",
+    "remove-require": "^1.0.0",
     "through2": "~0.5.1",
     "umd": "^3.0.0"
   },


### PR DESCRIPTION
This allows people to browserify a module that requires a module that
has already been bundled using `browserify --standalone`. This is
becoming increasingly popular now that browserify is seen as an easy
way to add es6 support to modules that are used in older versions of
node.