### PR TITLE
Update travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: node_js
 node_js:
-  - "0.8"
   - "0.10"
+  - "0.12"
+  - "iojs"
+
+# Use faster Docker architecture on Travis.
+sudo: false


### PR DESCRIPTION
This module doesn't work in 0.8.  I'm guessing we can drop support for that now?

We should start testing in 0.12 and iojs.  We can also use the newer, faster travis infrastructure by passing sudo: false