### PR TITLE
Update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "browser-pack": "bin/cmd.js"
   },
   "dependencies": {
-    "JSONStream": "~0.8.4",
+    "JSONStream": "~0.10.0",
     "combine-source-map": "~0.3.0",
     "concat-stream": "~1.4.1",
     "defined": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "JSONStream": "~0.8.4",
     "combine-source-map": "~0.3.0",
     "concat-stream": "~1.4.1",
-    "defined": "~0.0.0",
+    "defined": "^1.0.0",
     "through2": "~0.5.1",
     "umd": "^3.0.0"
   },


### PR DESCRIPTION
This part of https://github.com/substack/node-browserify/issues/707#issuecomment-96273418. Unfortunately we can't update to JSONStream@^1.0.1 (see https://github.com/dominictarr/JSONStream/pull/67), so ~0.10.0 will have to do.