### PR TITLE
Update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,16 +8,16 @@
   },
   "dependencies": {
     "JSONStream": "^1.0.3",
-    "combine-source-map": "~0.3.0",
+    "combine-source-map": "~0.5.0",
     "concat-stream": "~1.4.1",
     "defined": "^1.0.0",
-    "through2": "~0.5.1",
+    "through2": "^1.0.0",
     "umd": "^3.0.0"
   },
   "devDependencies": {
-    "tape": "^3.5.0",
+    "tape": "^4.0.0",
     "uglify-js": "1.3.5",
-    "convert-source-map": "~0.3.1",
+    "convert-source-map": "~1.1.0",
     "parse-base64vlq-mappings": "~0.1.1"
   },
   "scripts": {


### PR DESCRIPTION
The notable update here is **combine-source-map@~0.5.0**. Among other things, it now produces sourcemaps with a charset - that breaks browserify's tests. It also includes https://github.com/thlorenz/combine-source-map/pull/16 which fixes sourceFile paths for how transforms usually generate sourcemaps.

Updating **through2@^1.0.0**, just to bring it inline with browserify.

This should be published as 5.0.0.