### PR TITLE
reduce "prelude" size by 4 bytes

### DIFF
--- a/bin/prepublish.js
+++ b/bin/prepublish.js
@@ -4,5 +4,10 @@ var uglify = require('uglify-js');
 var fs = require('fs');
 var path = require('path');
 
-var src = fs.readFileSync(path.join(__dirname, '..', 'prelude.js'), 'utf8');
-fs.writeFileSync(path.join(__dirname, '..', '_prelude.js'), uglify(src));
+var minified = uglify.minify(
+  path.join(__dirname, '..', 'prelude.js'),
+  {compress: {side_effects: false}} // since nothing calls `outer`
+);
+// uglify insists on adding a semicolon at the end
+var code = minified.code.replace(/;$/, '');
+fs.writeFileSync(path.join(__dirname, '..', '_prelude.js'), code);

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "tape": "^4.0.0",
-    "uglify-js": "1.3.5",
+    "uglify-js": "2.4.23",
     "convert-source-map": "~1.1.0",
     "parse-base64vlq-mappings": "~0.1.1"
   },


### PR DESCRIPTION
minifier technology has come a long way.

this:
```js
var i = typeof require == "function" && require;
for (var o = 0; o < r.length; o++) s(r[o]);
```

became:
```js
for (var u = "function" == typeof require && require, i = 0; i < t.length; i++) o(t[i]);
```

##### full formatted prelude before:

```js
(function e(t, n, r) {
  function s(o, u) {
    if (!n[o]) {
      if (!t[o]) {
        var a = typeof require == "function" && require;
        if (!u && a) return a(o, !0);
        if (i) return i(o, !0);
        var f = new Error("Cannot find module '" + o + "'");
        throw f.code = "MODULE_NOT_FOUND", f
      }
      var l = n[o] = {
        exports: {}
      };
      t[o][0].call(l.exports, function(e) {
        var n = t[o][1][e];
        return s(n ? n : e)
      }, l, l.exports, e, t, n, r)
    }
    return n[o].exports
  }
  var i = typeof require == "function" && require;
  for (var o = 0; o < r.length; o++) s(r[o]);
  return s
})
```

##### full formatted prelude after:

```js
(function r(e, n, t) {
  function o(i, f) {
    if (!n[i]) {
      if (!e[i]) {
        var a = "function" == typeof require && require;
        if (!f && a) return a(i, !0);
        if (u) return u(i, !0);
        var c = new Error("Cannot find module '" + i + "'");
        throw c.code = "MODULE_NOT_FOUND", c
      }
      var p = n[i] = {
        exports: {}
      };
      e[i][0].call(p.exports, function(r) {
        var n = e[i][1][r];
        return o(n ? n : r)
      }, p, p.exports, r, e, n, t)
    }
    return n[i].exports
  }
  for (var u = "function" == typeof require && require, i = 0; i < t.length; i++) o(t[i]);
  return o
})
```