### PR TITLE
Update combine-source-map to current version

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "JSONStream": "^1.0.3",
-    "combine-source-map": "~0.6.1",
+    "combine-source-map": "^0.7.1",
     "defined": "^1.0.0",
     "through2": "^1.0.0",
     "umd": "^3.0.0"


### PR DESCRIPTION
This brings in several updates to inline-source-map,
including a fix for incorrect source maps when
empty files were require()-d
(see https://github.com/thlorenz/inline-source-map/pull/15)
