### PR TITLE
Expose `require` before initializing entries

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,10 +46,6 @@ module.exports = function (opts) {
             var pre = umd.prelude(opts.standalone).trim();
             stream.push(Buffer(pre + 'return '));
         }
-        else if (first && stream.hasExports) {
-            var pre = opts.externalRequireName || 'require';
-            stream.push(Buffer(pre + '='));
-        }
         if (first) stream.push(Buffer(prelude + '({'));
         
         if (row.sourceFile && !row.nomap) {
@@ -96,7 +92,16 @@ module.exports = function (opts) {
         if (first) stream.push(Buffer(prelude + '({'));
         entries = entries.filter(function (x) { return x !== undefined });
         
-        stream.push(Buffer('},{},' + JSON.stringify(entries) + ')'));
+        var postlude = [
+            '}',
+            '{}',
+            JSON.stringify(entries),
+            'this', // this === window
+            stream.hasExports ? 'true' : 'false',
+            JSON.stringify(opts.externalRequireName || 'require')
+        ].join(',');
+
+        stream.push(Buffer(postlude + ')'));
 
         if (opts.standalone && !first) {
             stream.push(Buffer(

--- a/prelude.js
+++ b/prelude.js
@@ -7,9 +7,9 @@
 // anything defined in a previous bundle is accessed via the
 // orig method which is the requireuire for previous bundles
 
-(function outer (modules, cache, entry) {
+(function outer (modules, cache, entry, global, hasExports, erName) {
     // Save the require from previous bundle to this closure if any
-    var previousRequire = typeof require == "function" && require;
+    var previousRequire = typeof global[erName] === "function" && global[erName];
 
     function newRequire(name, jumped){
         if(!cache[name]) {
@@ -17,7 +17,7 @@
                 // if we cannot find the module within our internal map or
                 // cache jump to the current global require ie. the last bundle
                 // that was added to the page.
-                var currentRequire = typeof require == "function" && require;
+                var currentRequire = typeof global[erName] === "function" && global[erName];
                 if (!jumped && currentRequire) return currentRequire(name, true);
 
                 // If there are other bundles on this page the require from the
@@ -37,8 +37,12 @@
         }
         return cache[name].exports;
     }
+
+    // Override the current require with this new one. This has to happend
+    // before we requires anything so cross bundle requiring works both ways.
+    if (hasExports) global[erName] = newRequire;
+
     for(var i=0;i<entry.length;i++) newRequire(entry[i]);
 
-    // Override the current require with this new one
     return newRequire;
 })

--- a/test/external.js
+++ b/test/external.js
@@ -1,0 +1,43 @@
+var vm = require('vm');
+var test = require('tap').test;
+var pack = require('../');
+
+test('external modules', function (t) {
+    t.plan(1);
+
+    var p1 = pack({ raw: true, hasExports: true });
+    var p2 = pack({ raw: true, hasExports: true });
+
+    var s1 = '';
+    var s2 = '';
+    p1.on('data', function (buf) { s1 += buf });
+    p2.on('data', function (buf) { s2 += buf });
+    p2.on('end', function () {
+        var context = vm.createContext({ });
+        vm.runInContext('require=' + s1, context);
+        vm.runInContext('require=' + s2, context);
+        t.equal(context.require('foo'), 'hello');
+        t.end();
+    });
+
+    p2.write({
+        id: 'foo',
+        source: 'module.exports = require("./bar")',
+        deps: { './bar': 'bar' },
+        entry: true
+    });
+
+    p1.write({
+        id: 'bar',
+        source: 'module.exports = require("./baz")',
+        deps: { './baz': 'baz' }
+    });
+
+    p2.write({
+        id: 'baz',
+        source: 'module.exports = "hello"'
+    });
+
+    p1.end();
+    p2.end();
+});


### PR DESCRIPTION
If you, from an entry file, tries to require a module from an external bundle which in turn requires a module from the first bundle, it breaks.

This fixes this by exposing the `newRequire` function before any entires are executed.

Side efects
- fixes `externalRequireName` to detect correct name from other bundles
- lets you have externals and standalone modules at the same time

One major thing to note is that this changes the number of arguments passed to the prelude. That may break some modules and is breaking [browser-unpack](https://github.com/substack/browser-unpack). Please see https://github.com/substack/browser-unpack/pull/13 for details.